### PR TITLE
Add Dev and Prod Database Instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ WORKDIR /app
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
 
+# Set production database URI
+ENV MONGODB_URI="mongodb+srv://4350_db_user:Con7AKxEZhrcnIMP@4350coapp.yfktzod.mongodb.net/myapp?appName=4350CoApp"
+
 # Copy the built jar from the build stage
 COPY --from=build /app/build/libs/*.jar app.jar
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=CoApp
-spring.mongodb.uri=mongodb+srv://4350_db_user:Con7AKxEZhrcnIMP@4350coapp.yfktzod.mongodb.net/myapp?appName=4350CoApp
+spring.mongodb.uri=${MONGODB_URI:mongodb+srv://4350_db_user:Con7AKxEZhrcnIMP@4350coapp.yfktzod.mongodb.net/myapp-dev?appName=4350CoApp}


### PR DESCRIPTION
### Summary / Description

When running locally, the app will run on the database. During deployment, it will run on the prod database instance within MongoDB Atlas

**Related Issues:** #4 

#### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

Describe how this PR has been tested.

- [ ] Unit tests
- [ ] Integration tests

#### Questions / Discussion Points

List any areas where you’d like reviewer input or have open questions.