### PR TITLE
Task/125 cookie issue on orender

### DIFF
--- a/docs/API-feat1.md
+++ b/docs/API-feat1.md
@@ -27,7 +27,7 @@ We will use JSON Web Token (JWT) for managing users authentication and users ses
 **Response 200 OK:**
 Response header:
 ```
-Set-Cookie: Authorization=<token>; HttpOnly; Secure; SameSite=Lax; Max-Age=3600
+Set-Cookie: Authorization=<token>; HttpOnly; Secure; SameSite=None; Max-Age=3600
 ```
 
 *Each cookie is assumed to be expired in 2 hours.*
@@ -80,7 +80,7 @@ N/A
 
 Response header:
 ```
-Set-Cookie: Authorization=; HttpOnly; Secure; SameSite=Lax; Max-Age=0
+Set-Cookie: Authorization=; HttpOnly; Secure; SameSite=None; Max-Age=0
 ``` 
 
 Response body:

--- a/src/main/java/com/backend/coapp/controller/AuthController.java
+++ b/src/main/java/com/backend/coapp/controller/AuthController.java
@@ -131,8 +131,7 @@ public class AuthController {
         ResponseCookie.from("Authorization", token)
             .httpOnly(true)
             .secure(true)
-            .sameSite("None") // Required for cross-subdomain
-            //            .domain("onrender.com") // Shared parent domain
+            .sameSite("None")
             .maxAge(this.authService.getTokenExpireDurationInSeconds())
             .path("/")
             .build();
@@ -153,7 +152,7 @@ public class AuthController {
         ResponseCookie.from("Authorization", "")
             .httpOnly(true)
             .secure(true)
-            .sameSite("Lax")
+            .sameSite("None")
             .path("/")
             .maxAge(0)
             .build();

--- a/src/test/java/com/backend/coapp/controller/AuthControllerTest.java
+++ b/src/test/java/com/backend/coapp/controller/AuthControllerTest.java
@@ -555,7 +555,7 @@ public class AuthControllerTest {
         .andExpect(header().string("Set-Cookie", containsString("Authorization=")))
         .andExpect(header().string("Set-Cookie", containsString("HttpOnly")))
         .andExpect(header().string("Set-Cookie", containsString("Secure")))
-        .andExpect(header().string("Set-Cookie", containsString("SameSite=Lax")))
+        .andExpect(header().string("Set-Cookie", containsString("SameSite=None")))
         .andExpect(header().string("Set-Cookie", containsString("Max-Age=0")))
         .andExpect(header().string("Set-Cookie", containsString("Path=/")));
   }


### PR DESCRIPTION
### Summary / Description

Fixed the issue with the cookie not being set properly due to the different domains ofthe  front-end and back-end
- Make `SameCite=None` for login and logout response

**Related Issues:** #125 

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [x] Documentation update

#### Test Evidence

Describe how this PR has been tested.

- [ ] Unit tests
- [ ] Integration tests

#### Questions / Discussion Points

List any areas where you’d like reviewer input or have open questions.