### PR TITLE
Return OVER_LIMIT_CHARACTER when user experience has too many char

### DIFF
--- a/docs/API-feat6.md
+++ b/docs/API-feat6.md
@@ -147,8 +147,22 @@ Response body:
 
 **Response 400 BAD REQUEST:**
 
- *The backend will return 400 if any field is invalid. 
- This includes null/emptty fields or role title/description is over character limit (We will specify exact number of character limit in the response's message).*
+Role title/description is over character limit (We will specify exact number of character limit in the response's message).*
+
+```json
+{
+ "message": "Role description must be less than 1000 characters.",
+ "error": "OVER_LIMIT_CHARACTER"
+}
+```
+or
+
+```json
+{
+ "message": "Role title must be less than 80 characters.",
+ "error": "OVER_LIMIT_CHARACTER"
+}
+```
 
 **Response 404 NOT FOUND:**
 
@@ -188,9 +202,22 @@ Response body:
 
 **Response 400 BAD REQUEST:**
 
-*The backend will return 400 if any field is invalid.
-This includes null/emptty fields or role title/description is over character limit (We will specify exact number of character limit in the response's message).*
+Role title/description is over character limit (We will specify exact number of character limit in the response's message).*
 
+```json
+{
+ "message": "Role description must be less than 1000 characters.",
+ "error": "OVER_LIMIT_CHARACTER"
+}
+```
+or
+
+```json
+{
+ "message": "Role title must be less than 80 characters.",
+ "error": "OVER_LIMIT_CHARACTER"
+}
+```
 
 **Response 404 NOT FOUND:**
 

--- a/src/main/java/com/backend/coapp/dto/request/UserExperienceRequest.java
+++ b/src/main/java/com/backend/coapp/dto/request/UserExperienceRequest.java
@@ -1,5 +1,6 @@
 package com.backend.coapp.dto.request;
 
+import com.backend.coapp.exception.genai.OverCharacterLimitException;
 import com.backend.coapp.exception.global.InvalidRequestException;
 import com.backend.coapp.util.ExperienceConstants;
 import java.time.LocalDate;
@@ -32,7 +33,7 @@ public class UserExperienceRequest implements IRequest {
     }
 
     if (roleTitle.length() > ExperienceConstants.MAX_JOB_TITLE_LENGTH) {
-      throw new InvalidRequestException(
+      throw new OverCharacterLimitException(
           "Role title must be less than %s characters"
               .formatted(ExperienceConstants.MAX_JOB_TITLE_LENGTH));
     }
@@ -42,8 +43,8 @@ public class UserExperienceRequest implements IRequest {
     }
 
     if (roleDescription.length() > ExperienceConstants.MAX_EXPERIENCE_DESCRIPTION_LENGTH) {
-      throw new InvalidRequestException(
-          "Role title must be less than %s characters."
+      throw new OverCharacterLimitException(
+          "Role description must be less than %s characters."
               .formatted(ExperienceConstants.MAX_EXPERIENCE_DESCRIPTION_LENGTH));
     }
 

--- a/src/test/java/com/backend/coapp/dto/request/UserExperienceRequestTest.java
+++ b/src/test/java/com/backend/coapp/dto/request/UserExperienceRequestTest.java
@@ -3,6 +3,7 @@ package com.backend.coapp.dto.request;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.backend.coapp.exception.genai.OverCharacterLimitException;
 import com.backend.coapp.exception.global.InvalidRequestException;
 import com.backend.coapp.util.ExperienceConstants;
 import java.time.LocalDate;
@@ -80,7 +81,7 @@ class UserExperienceRequestTest {
         buildValidRequest().toBuilder()
             .roleTitle("a".repeat(ExperienceConstants.MAX_JOB_TITLE_LENGTH + 1))
             .build();
-    assertThrows(InvalidRequestException.class, request::validateRequest);
+    assertThrows(OverCharacterLimitException.class, request::validateRequest);
   }
 
   @Test
@@ -110,7 +111,7 @@ class UserExperienceRequestTest {
         buildValidRequest().toBuilder()
             .roleDescription("a".repeat(ExperienceConstants.MAX_EXPERIENCE_DESCRIPTION_LENGTH + 1))
             .build();
-    assertThrows(InvalidRequestException.class, request::validateRequest);
+    assertThrows(OverCharacterLimitException.class, request::validateRequest);
   }
 
   @Test


### PR DESCRIPTION
### Summary / Description

As requested by Aidan, we want to return `OVER_LIMIT_CHARACTER` when users try to add/update experience that has too much characters

**Related Issues:** #182 

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [x] Documentation update

#### Test Evidence

Describe how this PR has been tested.

- [x] Unit tests
- [ ] Integration tests

#### Questions / Discussion Points

List any areas where you’d like reviewer input or have open questions.